### PR TITLE
fix: Don't send empty Authorization header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -286,9 +286,13 @@ async function startJob(
         body: JSON.stringify(body),
         headers: {
             "Content-Type": "application/json",
-            Authorization: bearerToken,
         },
     };
+
+    if (bearerToken) {
+        requestOptions.headers["Authorization"] = bearerToken;
+    }
+
     let response: Response;
 
     try {


### PR DESCRIPTION
Only set the Authorization header if there is a bearer token to send.