### PR TITLE
feat: Allow naming of result PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ const url = await run("itemId", options?);
 
 ### Options
 
-| Option     | Type    | Description                                                                                                                                                                       |
-| ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| culture    | string  | The culture to use for localization. For example `"en-US"`.                                                                                                                       |
-| dpi        | number  | The DPI to use when rendering a map print. Defaults to `96`.                                                                                                                      |
-| parameters | object  | An object specifying additional parameters to pass to the job.                                                                                                                    |
-| portalUrl  | string  | The URL of the ArcGIS Portal instance to use. Defaults to ArcGIS Online: `"https://www.arcgis.com"`.                                                                              |
-| resultName | string  | The desired name of the output file. |
-| token      | string  | The Portal access token to be used to access secured resources. If not provided requests to secured resources will fail.                                                          |
-| usePolling | boolean | When `true`, check for results by polling the service. When `false`, check for results using WebSockets. It is recommended to use WebSockets where possible. Defaults to `false`. |
+| Option         | Type    | Description                                                                                                                                                                       |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| culture        | string  | The culture to use for localization. For example `"en-US"`.                                                                                                                       |
+| dpi            | number  | The DPI to use when rendering a map print. Defaults to `96`.                                                                                                                      |
+| parameters     | object  | An object specifying additional parameters to pass to the job.                                                                                                                    |
+| portalUrl      | string  | The URL of the ArcGIS Portal instance to use. Defaults to ArcGIS Online: `"https://www.arcgis.com"`.                                                                              |
+| resultFileName | string  | The name assigned to the output file. It is used as the name of the tab when viewing the result in a browser and as the suggested name when downloading the result.               |
+| token          | string  | The Portal access token to be used to access secured resources. If not provided requests to secured resources will fail.                                                          |
+| usePolling     | boolean | When `true`, check for results by polling the service. When `false`, check for results using WebSockets. It is recommended to use WebSockets where possible. Defaults to `false`. |
 
 ## Examples
 
@@ -56,15 +56,6 @@ const url = await run("itemId");
 ```js
 const url = await run("itemId", {
     portalUrl: "https://server.domain.com/portal",
-});
-```
-
-### Run a report and specify the name of the resulting PDF
-
-```js
-const url = await run("itemId", {
-    portalUrl: "https://server.domain.com/portal",
-    resultName: "My Report"
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ const url = await run("itemId", options?);
 | dpi        | number  | The DPI to use when rendering a map print. Defaults to `96`.                                                                                                                      |
 | parameters | object  | An object specifying additional parameters to pass to the job.                                                                                                                    |
 | portalUrl  | string  | The URL of the ArcGIS Portal instance to use. Defaults to ArcGIS Online: `"https://www.arcgis.com"`.                                                                              |
+| resultName | string  | The name assigned to the output file. It is used as the name of the tab when viewing the result in a browser and as the suggested name when downloading the result. |
 | token      | string  | The Portal access token to be used to access secured resources. If not provided requests to secured resources will fail.                                                          |
 | usePolling | boolean | When `true`, check for results by polling the service. When `false`, check for results using WebSockets. It is recommended to use WebSockets where possible. Defaults to `false`. |
 
@@ -55,6 +56,15 @@ const url = await run("itemId");
 ```js
 const url = await run("itemId", {
     portalUrl: "https://server.domain.com/portal",
+});
+```
+
+### Run a report and specify the name of the resulting PDF
+
+```js
+const url = await run("itemId", {
+    portalUrl: "https://server.domain.com/portal",
+    resultName: "My Report"
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const url = await run("itemId", options?);
 | dpi        | number  | The DPI to use when rendering a map print. Defaults to `96`.                                                                                                                      |
 | parameters | object  | An object specifying additional parameters to pass to the job.                                                                                                                    |
 | portalUrl  | string  | The URL of the ArcGIS Portal instance to use. Defaults to ArcGIS Online: `"https://www.arcgis.com"`.                                                                              |
-| resultName | string  | The name assigned to the output file. It is used as the name of the tab when viewing the result in a browser and as the suggested name when downloading the result. |
+| resultName | string  | The desired name of the output file. |
 | token      | string  | The Portal access token to be used to access secured resources. If not provided requests to secured resources will fail.                                                          |
 | usePolling | boolean | When `true`, check for results by polling the service. When `false`, check for results using WebSockets. It is recommended to use WebSockets where possible. Defaults to `false`. |
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -93,6 +93,7 @@ describe("run", () => {
 
         const mockFetch = jest.fn();
         global.fetch = mockFetch;
+        jest.spyOn(global, "fetch");
 
         function mockResponseOnce(
             response: Record<string, unknown>,
@@ -126,11 +127,26 @@ describe("run", () => {
                     parameter1: "asdf",
                     parameter2: [1, 2, 3],
                 },
+                resultFileName: "My Report",
                 token: MOCK_PORTAL_TOKEN,
                 usePolling: true,
             })
         ).toBe(
             `${DEFAULT_REPORTING_URL}/service/job/result?ticket=${MOCK_REPORT_TICKET}&tag=${MOCK_REPORT_TAG}`
+        );
+        expect(global.fetch).toHaveBeenNthCalledWith(
+            3,
+            "https://apps.geocortex.com/reporting/service/job/run",
+            expect.objectContaining({
+                body:
+                    '{"template":{"itemId":"mock-portal-item-id","portalUrl":"https://www.arcgis.com","title":"My Report"},"parameters":[{"name":"parameter1","value":"asdf"},{"containsMultipleValues":true,"name":"parameter2","values":[1,2,3]}]}',
+                headers: {
+                    Authorization: "Bearer mock-reporting-token",
+                    "Content-Type": "application/json",
+                },
+                method: "POST",
+                responseType: "json",
+            })
         );
     });
     test("itemId option is required", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export interface RunOptions {
      * The name assigned to the output file. It is used as the name of the tab when viewing the
      * result in a browser and as the suggested name when downloading the result.
      */
-    resultName?: string
+    resultFileName?: string;
     /**
      * An optional ArcGIS token for accessing a secured report.
      * If the report is secured, or accesses secured ArcGIS content the token is required.
@@ -161,7 +161,7 @@ export async function run(
         options.parameters,
         options.culture,
         options.dpi,
-        options.resultName
+        options.resultFileName
     );
 
     // Watch or poll the job
@@ -282,7 +282,7 @@ async function startJob(
         template: {
             itemId: itemId,
             portalUrl,
-            title
+            title,
         },
         parameters: params,
         culture,

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,11 @@ export interface RunOptions {
      */
     portalUrl?: string;
     /**
+     * The name assigned to the output file. It is used as the name of the tab when viewing the
+     * result in a browser and as the suggested name when downloading the result.
+     */
+    resultName?: string
+    /**
      * An optional ArcGIS token for accessing a secured report.
      * If the report is secured, or accesses secured ArcGIS content the token is required.
      */
@@ -155,7 +160,8 @@ export async function run(
         bearerToken,
         options.parameters,
         options.culture,
-        options.dpi
+        options.dpi,
+        options.resultName
     );
 
     // Watch or poll the job
@@ -250,7 +256,8 @@ async function startJob(
     bearerToken: string,
     parameters?: Record<string, SingleParameterValue | MultiParameterValue>,
     culture?: string,
-    dpi?: number
+    dpi?: number,
+    title?: string
 ): Promise<string> {
     const params: Parameter[] = [];
     if (parameters) {
@@ -275,6 +282,7 @@ async function startJob(
         template: {
             itemId: itemId,
             portalUrl,
+            title
         },
         parameters: params,
         culture,


### PR DESCRIPTION
Add resultFileName property to RunOptions.
Use resultFileName to set Template.Title property when running a report