### PR TITLE
fix: value is undefined throws error on $type check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,7 @@ async function startJob(
                     name,
                     values: value,
                 });
-            } else if ((value as MapValue).$type) {
+            } else if ((value as MapValue)?.$type) {
                 params.push({...value as MapValue, name})
             } else {
                 params.push({


### PR DESCRIPTION
Fix issue where, when checking if a value has a $type property and the value is undefined an error is thrown, failing the job.